### PR TITLE
Corrected error for pieces' color

### DIFF
--- a/chess-game/Program.cs
+++ b/chess-game/Program.cs
@@ -173,9 +173,9 @@ namespace chess_game
                     Console.Write(' ');
                 }
                 Console.BackgroundColor = defaulBackground;
-                Console.ForegroundColor = defaulForeground;
                 Console.Write("\n");
             }
+            Console.ForegroundColor = defaulForeground;
         }
     }
 }


### PR DESCRIPTION
All the pieces are now displayed with a black outline, not only the first row.